### PR TITLE
disambiguate password validator requirement

### DIFF
--- a/Sprint-3/revise/implement/password-validator.test.js
+++ b/Sprint-3/revise/implement/password-validator.test.js
@@ -9,7 +9,7 @@ To be valid, a password must:
 - Have at least one English uppercase letter (A-Z)
 - Have at least one English lowercase letter (a-z)
 - Have at least one number (0-9)
-- Have at least one non-alphanumeric symbol ("!", "#", "$", "%", ".", "*", "&")
+- Have at least one of the following non-alphanumeric symbols: ("!", "#", "$", "%", ".", "*", "&")
 - Must not be any previous password in the passwords array. 
 
 You must breakdown this problem in order to solve it. Find one test case first and get that working


### PR DESCRIPTION
It was not clear whether all non-alphanumeric symbols were allowed or not.