### PR TITLE
Configure npm to not create lockfile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Rather than ignore it or have huge commit diffs, [tell npm](https://docs.npmjs.com/cli/v11/using-npm/config#package-lock) not to use lock files. 